### PR TITLE
Updated README for venv in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,13 @@ Python 3.9.1
 $ python -m venv --upgrade-deps venv
 ```
 
-Activate the virtual environment.
+Activate the virtual environment. For Linux/Mac OS, run
 ```
 $ source ./venv/bin/activate
+```
+For windows, run
+```
+.\venv\Scripts\Activate.ps1
 ```
 
 Install dependencies.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The new data acquisition system for the 40-foot radio telescope at the [Green Ba
 
 ## Setting Up
 
+### For Linux/Mac OS
 Clone the repo and `cd` into it.
 ```
 $ git clone https://github.com/radiolevity/threepio.git
@@ -21,21 +22,46 @@ Python 3.9.1
 $ python -m venv --upgrade-deps venv
 ```
 
-Activate the virtual environment. For Linux/Mac OS, run
+Activate the virtual environment.
 ```
 $ source ./venv/bin/activate
-```
-For windows, run
-```
-.\venv\Scripts\Activate.ps1
 ```
 
 Install dependencies.
 ```
-env $ pip install -r requirements.txt
+(venv) $ pip install -r requirements.txt
 ```
 
 Run
 ```
-env $ python threepio.py
+(venv) $ python threepio.py
+```
+
+### For Windows
+Clone the repo and `cd` into it.
+```
+$ git clone https://github.com/radiolevity/threepio.git
+$ cd threepio
+```
+
+**Threepio** requires Python 3.9.x. Using a virtual environment is strongly recommended.
+```
+$ python --version
+Python 3.9.1
+$ python -m venv --upgrade-deps venv
+```
+
+Activate the virtual environment.
+```
+$ .\venv\Scripts\Activate.ps1
+```
+
+Install dependencies.
+```
+(venv) $ python -m pip install -r requirements.txt
+```
+
+Run
+```
+(venv) $ python threepio.py
 ```


### PR DESCRIPTION
I added the command to activate `venv` on Windows platform.

EDIT:
Added a whole new section, since `pip` is not working on Windows and I had to use `python -m pip`.